### PR TITLE
Fixed init when applying on store load

### DIFF
--- a/ux/TreeStateful.js
+++ b/ux/TreeStateful.js
@@ -43,8 +43,7 @@ Ext.define('Ext.ux.TreeStateful', {
     view.saveState = me.saveState;
     if (view.getStore().isLoading()) {
       // restore nodes after load
-      view.getStore().on("load", me.applyState, {
-        scope: view,
+      view.getStore().on("load", me.applyState, this, {
         single: true
       });
     } else {


### PR DESCRIPTION
Hello,

I had some troubles with ext 6.5 and ajax loaded trees.

Could not find out exactly why the event was called on the view itself, but changing it to the plugin fixed it for me. By the way supplying the scope through the options array at the event attachment did not work for me.

Thanks for sharing the plugin!